### PR TITLE
OXT-1022: Add DEPENDS for ocaml-cross recipe

### DIFF
--- a/recipes-devtools/ocaml/ocaml-cross_4.04.0.bb
+++ b/recipes-devtools/ocaml/ocaml-cross_4.04.0.bb
@@ -14,6 +14,8 @@ inherit xenclient
 #inherit native
 inherit cross
 
+DEPENDS = "virtual/${TARGET_PREFIX}gcc libgcc"
+
 FILESEXTRAPATHS_prepend := "${THISDIR}/ocaml-cross:"
 
 S = "${WORKDIR}/ocaml-${PV}"


### PR DESCRIPTION
Fixes the build of the OCaml toolchain for the xenclient-stubdomain
machine.

Uncovered when switching to the upstream OCaml xenstored via a
common Xen recipe for xenstored and libxl.

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>