### PR TITLE
OXT-1253: ocaml: Define ocamlincdir to the ocaml headers.

### DIFF
--- a/classes/ocaml.bbclass
+++ b/classes/ocaml.bbclass
@@ -28,4 +28,8 @@ DEPENDS_append_class-target = " \
 ocamllibdir = "${libdir}/ocaml"
 export ocamllibdir
 
+# cross environment ocaml headers to interface with C sources.
+ocamlincdir = "${STAGING_LIBDIR_NATIVE}/${TARGET_SYS}/ocaml"
+export ocamlincdir
+
 OPN ?= "${@d.getVar('BPN').replace('ocaml-','')}"


### PR DESCRIPTION
Some recipes will use the path directly to interface with C sources. So
this should make it more confortable.
