### PR TITLE
OXT-1279: ocaml: absolute path in shebang overflow.

### DIFF
--- a/recipes-devtools/ocaml/files/shebang-use-env.patch
+++ b/recipes-devtools/ocaml/files/shebang-use-env.patch
@@ -1,0 +1,15 @@
+Index: ocaml-4.04.2/stdlib/Makefile
+===================================================================
+--- ocaml-4.04.2.orig/stdlib/Makefile
++++ ocaml-4.04.2/stdlib/Makefile
+@@ -54,8 +54,8 @@ camlheaderi target_camlheaderi: \
+   header.c ../config/Makefile
+ 	if $(HASHBANGSCRIPTS); then \
+ 	  for suff in '' d i; do \
+-	    echo '#!$(BINDIR)/ocamlrun'$$suff > camlheader$$suff && \
+-	    echo '#!$(TARGET_BINDIR)/ocamlrun'$$suff >target_camlheader$$suff; \
++	    echo '#!/usr/bin/env ocamlrun'$$suff > camlheader$$suff && \
++	    echo '#!/usr/bin/env ocamlrun'$$suff >target_camlheader$$suff; \
+ 	  done && \
+ 	  echo '#!' | tr -d '\012' > camlheader_ur; \
+ 	else \

--- a/recipes-devtools/ocaml/ocaml-4.04.inc
+++ b/recipes-devtools/ocaml/ocaml-4.04.inc
@@ -5,6 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=4f72f33f302a53dc329f4d3819fe14f9"
 SRC_URI = " \
     http://caml.inria.fr/pub/distrib/ocaml-4.04/ocaml-${PV}.tar.xz \
     file://oe-linux-configure.patch \
+    file://shebang-use-env.patch \
 "
 SRC_URI[md5sum] = "a230f5f352318575870abb326db7355b"
 SRC_URI[sha256sum] = "d158ed3e9446b300554baeaaa8cca2e9491420b505a9878940205074e2970f2e"


### PR DESCRIPTION
ocamlc bytecode will embbed a shebang pointing to the ocamlrun
interpreter. When ocaml-native is built with Bitbake in a container, the
absolute path to ocamlrun easily exhaust the common 127 character limit
of the shebang.

Bitbake will setup the environment to handle
hosttools/sysroot-native/sysroot invocations, so it makes sense to use
env in the shebang instead of an absolute path and rely on the
environment provided by Bitbake to find the appropriate ocamlrun
interpreter, and avoid shebang overflow.

OXT-1279