### PR TITLE
OXT-1294: ocaml-dbus: Attend Makefile missing dependency.

### DIFF
--- a/recipes-devtools/ocaml-dbus/files/fix-build-dependencies.patch
+++ b/recipes-devtools/ocaml-dbus/files/fix-build-dependencies.patch
@@ -1,0 +1,20 @@
+Index: ocaml_dbus-0.24/Makefile
+===================================================================
+--- ocaml_dbus-0.24.orig/Makefile
++++ ocaml_dbus-0.24/Makefile
+@@ -44,13 +44,13 @@ dbus_stubs.a: libdbus_stubs.a
+ libdbus_stubs.a: dbus_stubs.o
+ 	$(OCAMLMKLIB) -o dbus_stubs $(DBUS_LDFLAGS) $+
+ 
+-%.cmo: %.ml
++%.cmo: %.ml %.cmi
+ 	$(OCAMLC) -c -o $@ $<
+ 
+ %.cmi: %.mli
+ 	$(OCAMLC) -c -o $@ $<
+ 
+-%.cmx: %.ml
++%.cmx: %.ml %.cmi
+ 	$(OCAMLOPT) $(OCAMLOPTFLAGS) -c -o $@ $<
+ 
+ %.o: %.c

--- a/recipes-devtools/ocaml-dbus/ocaml-dbus_0.24.bb
+++ b/recipes-devtools/ocaml-dbus/ocaml-dbus_0.24.bb
@@ -18,6 +18,7 @@ SRC_URI = " \
     file://fix-error-name-lookup.patch \
     file://fix-memleak.patch \
     file://fix-multithread.patch \
+    file://fix-build-dependencies.patch \
 "
 SRC_URI[md5sum] = "b769af9141a5c073056ed46ef76ba5be"
 SRC_URI[sha256sum] = "7c793987668e4236c63857469d2abe4a460e0b0954aa7d3262c6d9bb3c24bfdd"


### PR DESCRIPTION
dBus.mli interface has to be built before dBus.ml implementation.
Add the missing dependency to the Makefile.

OXT-1294