### PR TITLE
findlib: fix typo of native class

### DIFF
--- a/recipes-devtools/findlib/findlib_1.7.3.bb
+++ b/recipes-devtools/findlib/findlib_1.7.3.bb
@@ -1,3 +1,3 @@
 require findlib-${PV}.inc
 
-BBCLASSEXSTEND = "native"
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
The BBCLASSEXTEND is the correct one.

Signed-off-by: Phong Tran <tranmanphong@gmail.com>