### PR TITLE
OXT-1704: ocaml: Amend cross-compilation.

### DIFF
--- a/classes/findlib.bbclass
+++ b/classes/findlib.bbclass
@@ -43,6 +43,11 @@ do_local_findlib_conf() {
     cat << EOF > ${OCAMLFIND_CONF}
 destdir="${D}${sitelibdir}"
 path="${OCAMLLIB}/site-lib:${STAGING_LIBDIR}/ocaml/site-lib"
+ldconf="ignore"
+ocamlc="ocamlc.opt"
+ocamlopt="ocamlopt.opt"
+ocamldep="ocamldep.opt"
+ocamldoc="ocamldoc.opt"
 EOF
 }
 addtask do_local_findlib_conf before do_configure after do_patch

--- a/classes/findlib.bbclass
+++ b/classes/findlib.bbclass
@@ -2,7 +2,8 @@ DEPENDS_append_class-native = " \
     findlib-native \
 "
 DEPENDS_append_class-target = " \
-    virtual/${TARGET_PREFIX}ocamlfind \
+    findlib-native \
+    virtual/${TARGET_PREFIX}ocamlfind-meta \
 "
 
 # location where ocamlfind install puts the packages.

--- a/recipes-devtools/camomile/camomile_0.8.5.bb
+++ b/recipes-devtools/camomile/camomile_0.8.5.bb
@@ -43,7 +43,7 @@ do_configure() {
 # This does not happen using camlp4 byte-code instead of native compiled.
 PARALLEL_MAKE = ""
 do_compile() {
-    oe_runmake
+    oe_runmake OCAMLOPT="ocamlopt"
 }
 
 do_install() {

--- a/recipes-devtools/camomile/camomile_0.8.5.bb
+++ b/recipes-devtools/camomile/camomile_0.8.5.bb
@@ -15,6 +15,7 @@ DEPENDS = " \
 SRC_URI = " \
     http://github.com/yoriyuki/Camomile/releases/download/rel-${PV}/camomile-${PV}.tar.bz2 \
     file://ocaml-camomile-destdir.patch \
+    file://bytecode-ocamlbest.patch \
 "
 SRC_URI[md5sum] = "1e25b6cd4efd26ab38a667db18d83f02"
 SRC_URI[sha256sum] = "85806b051cf059b93676a10a3f66051f7f322cad6e3248172c3e5275f79d7100"
@@ -49,3 +50,5 @@ do_compile() {
 do_install() {
     oe_runmake DESTDIR="${D}" install
 }
+
+INSANE_SKIP_${PN}-dev = "file-rdeps"

--- a/recipes-devtools/camomile/files/bytecode-ocamlbest.patch
+++ b/recipes-devtools/camomile/files/bytecode-ocamlbest.patch
@@ -1,0 +1,43 @@
+--- a/configure
++++ b/configure
+@@ -1969,23 +1969,23 @@ fi
+ 
+ 
+ OCAMLBEST=byte
+-if test "$OCAMLOPT" = no ; then
+-	{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Cannot find ocamlopt; bytecode compilation only." >&5
+-$as_echo "$as_me: WARNING: Cannot find ocamlopt; bytecode compilation only." >&2;}
+-else
+-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking ocamlopt version" >&5
+-$as_echo_n "checking ocamlopt version... " >&6; }
+-	TMPVERSION=`$OCAMLOPT -v | sed -n -e 's|.*version* *\(.*\)$|\1|p' `
+-	if test "$TMPVERSION" != "$OCAMLVERSION" ; then
+-	    { $as_echo "$as_me:${as_lineno-$LINENO}: result: differs from ocamlc; ocamlopt discarded." >&5
+-$as_echo "differs from ocamlc; ocamlopt discarded." >&6; }
+-	    OCAMLOPT=no
+-	else
+-	    { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
+-$as_echo "ok" >&6; }
+-	    OCAMLBEST=opt
+-	fi
+-fi
++#if test "$OCAMLOPT" = no ; then
++#	{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Cannot find ocamlopt; bytecode compilation only." >&5
++#$as_echo "$as_me: WARNING: Cannot find ocamlopt; bytecode compilation only." >&2;}
++#else
++#	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking ocamlopt version" >&5
++#$as_echo_n "checking ocamlopt version... " >&6; }
++#	TMPVERSION=`$OCAMLOPT -v | sed -n -e 's|.*version* *\(.*\)$|\1|p' `
++#	if test "$TMPVERSION" != "$OCAMLVERSION" ; then
++#	    { $as_echo "$as_me:${as_lineno-$LINENO}: result: differs from ocamlc; ocamlopt discarded." >&5
++#$as_echo "differs from ocamlc; ocamlopt discarded." >&6; }
++#	    OCAMLOPT=no
++#	else
++#	    { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
++#$as_echo "ok" >&6; }
++#	    OCAMLBEST=opt
++#	fi
++#fi
+ 
+ # checking for ocamlc.opt
+ # Extract the first word of "ocamlc.opt", so it can be a program name with args.

--- a/recipes-devtools/findlib/findlib-cross_1.7.3.bb
+++ b/recipes-devtools/findlib/findlib-cross_1.7.3.bb
@@ -1,10 +1,15 @@
 require findlib-${PV}.inc
 
 PROVIDES = " \
-    virtual/${TARGET_PREFIX}ocamlfind \
+    virtual/${TARGET_PREFIX}ocamlfind-meta \
 "
 
 PN = "findlib-cross-${TARGET_ARCH}"
+
+do_install_append() {
+    rm -r ${D}${bindir}
+    rm -r ${D}${mandir}
+}
 
 # Ignore how TARGET_ARCH is computed.
 TARGET_ARCH[vardepvalue] = "${TARGET_ARCH}"

--- a/recipes-devtools/ocaml-dbus/files/static-only.patch
+++ b/recipes-devtools/ocaml-dbus/files/static-only.patch
@@ -1,0 +1,21 @@
+--- a/Makefile
++++ b/Makefile
+@@ -64,12 +64,16 @@ check:
+ 
+ .PHONY: install
+ install: $(LIBS)
+-	ocamlfind install -destdir $(OCAMLDESTDIR) -ldconf ignore $(OCAML_PKG_NAME) META $(INTERFACES) $(LIBS) *.a *.so *.cmx
++	ocamlfind install -destdir $(OCAMLDESTDIR) \
++		-ldconf ignore $(OCAML_PKG_NAME) META $(INTERFACES) $(LIBS) \
++		$(wildcard *.so) $(wildcard *.a) $(wildcard *.cmx)
+ 
+ install-opt: install
+ 
+ install-byte: all-byte
+-	ocamlfind install -destdir $(OCAMLDESTDIR) -ldconf ignore $(OCAML_PKG_NAME) META $(INTERFACES) $(LIBS_BYTE) *.a *.so
++	ocamlfind install -destdir $(OCAMLDESTDIR) \
++		-ldconf ignore $(OCAML_PKG_NAME) META $(INTERFACES) $(LIBS_BYTE) \
++		$(wildcard *.so) $(wildcard *.a)
+ 
+ uninstall:
+ 	ocamlfind remove -destdir $(OCAMLDESTDIR) $(OCAML_PKG_NAME)

--- a/recipes-devtools/ocaml-dbus/ocaml-dbus_0.24.bb
+++ b/recipes-devtools/ocaml-dbus/ocaml-dbus_0.24.bb
@@ -39,3 +39,5 @@ do_compile() {
 do_install() {
     oe_runmake OCAMLDESTDIR="$(ocamlfind printconf destdir)" install
 }
+
+INSANE_SKIP_${PN}-dev = "file-rdeps"

--- a/recipes-devtools/ocaml-dbus/ocaml-dbus_0.24.bb
+++ b/recipes-devtools/ocaml-dbus/ocaml-dbus_0.24.bb
@@ -19,6 +19,7 @@ SRC_URI = " \
     file://fix-memleak.patch \
     file://fix-multithread.patch \
     file://fix-build-dependencies.patch \
+    file://static-only.patch \
 "
 SRC_URI[md5sum] = "b769af9141a5c073056ed46ef76ba5be"
 SRC_URI[sha256sum] = "7c793987668e4236c63857469d2abe4a460e0b0954aa7d3262c6d9bb3c24bfdd"

--- a/recipes-devtools/ocaml/files/0001-cross-Add-cross-compilation-rules.patch
+++ b/recipes-devtools/ocaml/files/0001-cross-Add-cross-compilation-rules.patch
@@ -1,0 +1,78 @@
+From 0ce7d96a184a7b7261497bb466386c3f4211660b Mon Sep 17 00:00:00 2001
+From: Eric Chanudet <chanudete@ainfosec.com>
+Date: Mon, 21 Oct 2019 11:45:54 -0400
+Subject: [PATCH] cross: Add cross-compilation rules.
+
+Use the native compiler to build a cross build environment and
+toolchain.
+This patch is adapted from:
+https://github.com/gerdstolpmann/ocaml/commit/34bfa2efe06d99603d951d1d34240d40762b2c2b
+
+Signed-off-by: Eric Chanudet <chanudete@ainfosec.com>
+---
+ Makefile | 35 ++++++++++++++++++++++++++++++++++-
+ 1 file changed, 34 insertions(+), 1 deletion(-)
+
+Index: ocaml-4.04.2/Makefile
+===================================================================
+--- ocaml-4.04.2.orig/Makefile
++++ ocaml-4.04.2/Makefile
+@@ -198,6 +198,42 @@ base.opt:
+ 	$(MAKE) ocamlopt.opt
+ 	$(MAKE) otherlibrariesopt
+ 
++# Cross compilation support.
++cross-all:
++	$(MAKE) cross-boot
++	$(MAKE) all
++
++cross-opt: cross-all
++	$(MAKE) opt
++
++cross-boot:
++	if ! ocamlc; then \
++	  echo "No host compiler found in PATH" >&2; \
++	  exit 1; \
++	fi
++	rm -f boot/*
++	for cmd in ocamlrun ocamlyacc; do \
++	  ln -sf "$$(which $${cmd})" boot/; \
++	done
++	for cmd in ocamlc ocamldep ocamllex; do \
++	  ln -sf "$$(which $${cmd}.byte)" boot/$${cmd}; \
++	done
++	if test -z "$(STAGING_OCAMLLIB)"; then \
++	  hostlib="$$(ocamlc -where)"; \
++	else \
++	  hostlib="$(STAGING_OCAMLLIB)"; \
++	fi && \
++	for file in \
++	  "$${hostlib}/stdlib.cma" \
++	  "$${hostlib}/std_exit.cmo" \
++	  $${hostlib}/*.cmi; do \
++	    ln -sf "$${file}" boot/; \
++	done
++	echo "#! /usr/bin/env ocamlrun" > boot/camlheader
++	rm -f byterun/ocamlrun
++	ln -sf ../boot/ocamlrun byterun/
++
++
+ # Installation
+ 
+ COMPLIBDIR=$(LIBDIR)/compiler-libs
+@@ -225,7 +261,7 @@ install:
+ 	  dllunix$(EXT_DLL) dllgraphics$(EXT_DLL) dllstr$(EXT_DLL)
+ 	cd byterun; $(MAKE) install
+ 	cp ocamlc $(INSTALL_BINDIR)/ocamlc.byte$(EXE)
+-	cp ocaml $(INSTALL_BINDIR)/ocaml$(EXE)
++	cp ocaml $(INSTALL_BINDIR)/ocaml$(EXE) || true # Not for cross comp.
+ 	cd stdlib; $(MAKE) install
+ 	cp lex/ocamllex $(INSTALL_BINDIR)/ocamllex.byte$(EXE)
+ 	cp $(CAMLYACC)$(EXE) $(INSTALL_BINDIR)/ocamlyacc$(EXE)
+@@ -778,5 +814,6 @@ distclean:
+ .PHONY: ocamltoolsopt.opt ocamlyacc opt-core opt opt.opt otherlibraries
+ .PHONY: otherlibrariesopt package-macosx promote promote-cross
+ .PHONY: restore runtime runtimeopt makeruntimeopt world world.opt
++.PHONY: cross-all cross-opt cross-boot
+ 
+ include .depend

--- a/recipes-devtools/ocaml/ocaml-cross_4.04.2.bb
+++ b/recipes-devtools/ocaml/ocaml-cross_4.04.2.bb
@@ -73,6 +73,10 @@ do_compile() {
     oe_runmake OCAMLLIB="${STAGING_LIBDIR_NATIVE}/ocaml" cross-opt
 }
 
+do_install_append() {
+    rm "${D}${bindir}/ocamlrun"
+}
+
 # Ignore how TARGET_ARCH is computed.
 TARGET_ARCH[vardepvalue] = "${TARGET_ARCH}"
 

--- a/recipes-test/ocaml-findlib-test/files/ocaml-ls.ml
+++ b/recipes-test/ocaml-findlib-test/files/ocaml-ls.ml
@@ -1,0 +1,23 @@
+open Unix
+
+let list_dir path = 
+    try
+        let hnd = Unix.opendir path in
+        let rec entries () =
+            try
+                match Unix.readdir hnd with
+                | "." | ".." -> entries ()
+                | e          -> e :: entries ()
+            with End_of_file -> []
+        in
+            ignore (List.map print_endline (List.map (Filename.concat path) (entries ())));
+            Unix.closedir hnd
+    with _ -> print_endline "Failed"
+
+let () =
+    if Array.length Sys.argv = 1 then
+        list_dir "./"
+    else
+        for i = 1 to Array.length Sys.argv - 1 do
+            list_dir Sys.argv.(i)
+        done

--- a/recipes-test/ocaml-findlib-test/ocaml-ls_1.0.bb
+++ b/recipes-test/ocaml-findlib-test/ocaml-ls_1.0.bb
@@ -1,0 +1,24 @@
+SUMMARY = "OCaml test for findlib."
+DESCRIPTION = "Trivial ls in CAML to test the OCaml basic toolchain."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+SECTION = "devel/ocaml"
+
+SRC_URI = " \
+    file://ocaml-ls.ml \
+"
+
+S = "${WORKDIR}"
+
+inherit ocaml findlib
+
+do_configure[noexec] = "1"
+
+do_compile() {
+    ocamlfind opt -linkpkg -package unix ocaml-ls.ml -o ocaml-ls
+}
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${S}/ocaml-ls ${D}${bindir}/ocaml-ls
+}

--- a/recipes-test/ocaml-helloworld/files/helloworld.ml
+++ b/recipes-test/ocaml-helloworld/files/helloworld.ml
@@ -1,0 +1,1 @@
+print_string "Hello world!\n";;

--- a/recipes-test/ocaml-helloworld/ocaml-helloworld_1.0.bb
+++ b/recipes-test/ocaml-helloworld/ocaml-helloworld_1.0.bb
@@ -1,0 +1,24 @@
+SUMMARY = "Simple helloworld! in CAML."
+DESCRIPTION = "Simple helloworld! in CAML to test the OCaml basic toolchain."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://helloworld.ml;md5=4ef7127acc7f38322c009092a0050f59"
+SECTION = "devel/ocaml"
+
+SRC_URI = " \
+    file://helloworld.ml \
+"
+
+S = "${WORKDIR}"
+
+inherit ocaml
+
+do_configure[noexec] = "1"
+
+do_compile() {
+    ocamlc -o helloworld helloworld.ml
+}
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${S}/helloworld ${D}${bindir}/helloworld
+}


### PR DESCRIPTION
Amend the OCaml recipes to produce a cross toolchain and target binaries that link with and only with the target environment.

Most of the complexity is worked-around by configuring the cross toolchain to link statically instead of producing dynamic objects from the OCaml sources. Still take advantage of using native/bytecode OCaml tools for some corner cases (e.g, `camomile`).

Note: `file-rdep` does not seem to trigger using OE layers in Pyro branches.

Requires:
- https://github.com/OpenXT/xenclient-oe/pull/1280
- https://github.com/OpenXT/toolstack/pull/41