### PR TITLE
OXT-1704: Fix cross-compilation in more recent containers.

### DIFF
--- a/recipes-devtools/camomile/camomile_0.8.5.bb
+++ b/recipes-devtools/camomile/camomile_0.8.5.bb
@@ -8,7 +8,6 @@ LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d8045f3b8f929c1cb29a1e3fd737b499"
 
 DEPENDS = " \
-    ocaml-native \
     camlp4-native \
 "
 
@@ -44,7 +43,7 @@ do_configure() {
 # This does not happen using camlp4 byte-code instead of native compiled.
 PARALLEL_MAKE = ""
 do_compile() {
-    oe_runmake OCAMLOPT="ocamlopt"
+    oe_runmake OCAMLOPT="ocamlopt" OCAMLC="ocamlc"
 }
 
 do_install() {

--- a/recipes-devtools/ocaml/ocaml-4.04.inc
+++ b/recipes-devtools/ocaml/ocaml-4.04.inc
@@ -18,6 +18,7 @@ do_configure() {
                 -prefix ${prefix} \
                 -libdir ${libdir}/ocaml \
                 -mandir ${datadir}/man \
+                -fPIC \
                 ${EXTRA_CONF}
 }
 do_configure_append() {

--- a/recipes-devtools/ocaml/ocaml-cross_4.04.2.bb
+++ b/recipes-devtools/ocaml/ocaml-cross_4.04.2.bb
@@ -40,9 +40,9 @@ do_configure_x86() {
                 -libdir ${libdir}/ocaml \
                 -mandir ${datadir}/man \
                 -fPIC \
-                -cc "${TARGET_PREFIX}gcc -m32 --sysroot=${STAGING_DIR_TARGET}" \
+                -cc "${TARGET_PREFIX}gcc -fPIC -m32 --sysroot=${STAGING_DIR_TARGET}" \
                 -as "${TARGET_PREFIX}as --32" \
-                -aspp "${TARGET_PREFIX}gcc -m32 -c" \
+                -aspp "${TARGET_PREFIX}gcc -fPIC -m32 -c" \
                 -libs "-Wl,--sysroot=${STAGING_DIR_TARGET}" \
                 -host ${TARGET_SYS} \
                 -partialld "ld -r -melf_i386" \
@@ -60,9 +60,9 @@ do_configure_x86-64() {
                 -libdir ${libdir}/ocaml \
                 -mandir ${datadir}/man \
                 -fPIC \
-                -cc "${TARGET_PREFIX}gcc --sysroot=${STAGING_DIR_TARGET}" \
+                -cc "${TARGET_PREFIX}gcc -fPIC --sysroot=${STAGING_DIR_TARGET}" \
                 -as "${TARGET_PREFIX}as" \
-                -aspp "${TARGET_PREFIX}gcc -c" \
+                -aspp "${TARGET_PREFIX}gcc -c -fPIC" \
                 -libs "-Wl,--sysroot=${STAGING_DIR_TARGET}" \
                 -host ${TARGET_SYS} \
                 -partialld "${TARGET_PREFIX}ld -r" \


### PR DESCRIPTION
**REQUIRES MORE RECENT BUILD CONTAINER.**

https://github.com/OpenXT/meta-openxt-ocaml-platform relies on having `ocamlrun` provided by `ocaml-native` and use it to run bytecode outputs from `ocaml-cross`. `camomile` therefor has to use `ocamlc` instead of `ocamlc.opt`.

EDIT: That first part will still break the cross environment. `ocamlc` will rely on `ld` from the hosttools to link the libraries. So the hosttools `ld` has to be able to link the target libraries. This is not the case on jessie container (but will work with buster based):
```
unrecognized relocation (0x2a) in section `.text'
```
That is `R_X86_64_REX_GOTPCRELX` which requires at least `binutils 2.26` (jessie had 2.25).

As it turns out, the `-fPIC` argument that `configure` takes for the ocaml compiler recipes does not propagate all the way down. Re-introduce `-fPIC` to gcc tools invocation. This might be doable some other way as the libraries that trigger relocation errors without this change do exist in a PIC version already, but do not seem to be used.