### PR TITLE
OXT-1701: layer: Zeus compatibility.

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -13,4 +13,5 @@ BBFILE_COLLECTIONS += "meta-openxt-ocaml-platform"
 BBFILE_PATTERN_meta-openxt-ocaml-platform := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-openxt-ocaml-platform = "8"
 
-LAYERVERSION_meta-openxt-ocaml-platform = "1"
+LAYERVERSION_meta-openxt-ocaml-platform = "2"
+LAYERSERIES_COMPAT_meta-openxt-ocaml-platform = "zeus"

--- a/recipes-devtools/ocaml/ocaml-cross_4.04.2.bb
+++ b/recipes-devtools/ocaml/ocaml-cross_4.04.2.bb
@@ -7,7 +7,7 @@ SRC_URI += " \
 DEPENDS += " \
     virtual/${TARGET_PREFIX}binutils \
     virtual/${TARGET_PREFIX}gcc \
-    virtual/${TARGET_PREFIX}libc-for-gcc \
+    virtual/libc \
     libgcc \
     ocaml-native \
 "


### PR DESCRIPTION
libc-for-gcc no longer exist in zeus, use virtual/libc as intended.

Bump the LAYERVERSION number due to the change above and change the
LAYERSERIES_COMPAT to zeus.