### PR TITLE
ocaml: local findlib package database

### DIFF
--- a/classes/findlib.bbclass
+++ b/classes/findlib.bbclass
@@ -33,7 +33,7 @@ FILES_${PN}-dbg = " \
 # See http://projects.camlcity.org/projects/dl/findlib-1.4/doc/ref-html/r775.html.
 # OCAMLFIND_CONF: overrides the location of the configuration file
 # findlib.conf. It must contain the absolute path name of this file.
-OCAMLFIND_CONF = "${S}/local-findlib.conf"
+OCAMLFIND_CONF = "${B}/local-findlib.conf"
 export OCAMLFIND_CONF
 
 # Define where to install new META files and where to find existing ones.
@@ -50,7 +50,7 @@ ocamldep="ocamldep.opt"
 ocamldoc="ocamldoc.opt"
 EOF
 }
-addtask do_local_findlib_conf before do_configure after do_patch
+addtask do_local_findlib_conf before do_configure after do_prepare_recipe_sysroot
 do_local_findlib_conf[doc] = "Create a volatile local findlib.conf, according to the bitbake staging, for ocamlfind to use."
 # See: bitbake.git: 67a7b8b0 build: don't use $B as the default cwd for functions
 do_local_findlib_conf[dirs] = "${B}"


### PR DESCRIPTION
The database should be in ${B}, no in ${S}.

If externalsrc is inherited and a local tree is used, since this recipe
is MACHINE specific, it might find the configuration intended for
another MACHINE in its sources and used it leading to all sorts of
problems.

do_{fetch,unpack,patch} are not defined with externalsrc.bbclass, use
do_prepare_recipe_sysroot. It is more accurate since the configuration
file is only generated from environment variables and static path.
