### PR TITLE
ocaml: local findlib package database

### DIFF
--- a/classes/findlib.bbclass
+++ b/classes/findlib.bbclass
@@ -10,6 +10,9 @@ DEPENDS_append_class-target = " \
 sitelibdir = "${ocamllibdir}/site-lib"
 export sitelibdir
 
+OCAMLFIND_CONF = "${STAGING_DIR_NATIVE}/etc/findlib.conf"
+export OCAMLFIND_CONF
+
 FILES_${PN} = " \
     ${sitelibdir}/*/*${SOLIBSDEV} \
     ${bindir}/* \
@@ -30,31 +33,18 @@ FILES_${PN}-dbg = " \
     /usr/src/debug \
 "
 
-# See http://projects.camlcity.org/projects/dl/findlib-1.4/doc/ref-html/r775.html.
-# OCAMLFIND_CONF: overrides the location of the configuration file
-# findlib.conf. It must contain the absolute path name of this file.
-OCAMLFIND_CONF = "${S}/local-findlib.conf"
-export OCAMLFIND_CONF
-
-# Define where to install new META files and where to find existing ones.
-# This has to be coherent with findlib{,-native} recipe configuration,
-# site-lib wise.
-do_local_findlib_conf() {
-    cat << EOF > ${OCAMLFIND_CONF}
-destdir="${D}${sitelibdir}"
-path="${OCAMLLIB}/site-lib:${STAGING_LIBDIR}/ocaml/site-lib"
-ldconf="ignore"
-ocamlc="ocamlc.opt"
-ocamlopt="ocamlopt.opt"
-ocamldep="ocamldep.opt"
-ocamldoc="ocamldoc.opt"
-EOF
+do_amend_findlib_conf() {
+    sed -i \
+        -e 's|^destdir=.*|destdir="${D}${sitelibdir}"|' \
+        -e 's|^path=.*|path="${OCAMLLIB}/site-lib:${STAGING_LIBDIR}/ocaml/site-lib"|' \
+            "${OCAMLFIND_CONF}"
+    if ! grep -q '^ldconf=' "${OCAMLFIND_CONF}"; then
+        echo 'ldconf="ignore"' >> "${OCAMLFIND_CONF}"
+    else
+        sed -i -e 's|^ldconf=.*|ldconf="ignore"|' "${OCAMLFIND_CONF}"
+    fi
 }
-addtask do_local_findlib_conf before do_configure after do_patch
-do_local_findlib_conf[doc] = "Create a volatile local findlib.conf, according to the bitbake staging, for ocamlfind to use."
-# See: bitbake.git: 67a7b8b0 build: don't use $B as the default cwd for functions
-do_local_findlib_conf[dirs] = "${B}"
-do_local_findlib_conf[deptask] = "do_populate_sysroot"
+do_prepare_recipe_sysroot[postfuncs] += "do_amend_findlib_conf"
 
 do_install_prepend() {
     install -d ${D}${sitelibdir}

--- a/recipes-devtools/findlib/findlib-common.inc
+++ b/recipes-devtools/findlib/findlib-common.inc
@@ -16,7 +16,8 @@ do_configure() {
     ./configure \
         -bindir ${bindir} \
         -mandir ${datadir}/man \
-        -sitelib ${ocamllibdir}/site-lib
+        -sitelib ${ocamllibdir}/site-lib \
+        -config ${sysconfdir}/findlib.conf
 }
 
 do_compile() {
@@ -26,7 +27,7 @@ do_compile() {
     oe_runmake opt
 }
 
-EXTRA_OEMAKE_append = " prefix='${D}'"
+EXTRA_OEMAKE_append += "prefix='${D}'"
 do_install() {
     oe_runmake install
 }

--- a/recipes-devtools/findlib/findlib-cross_1.7.3.bb
+++ b/recipes-devtools/findlib/findlib-cross_1.7.3.bb
@@ -7,8 +7,9 @@ PROVIDES = " \
 PN = "findlib-cross-${TARGET_ARCH}"
 
 do_install_append() {
-    rm -r ${D}${bindir}
-    rm -r ${D}${mandir}
+    rm -rf ${D}${bindir}
+    rm -rf ${D}${mandir}
+    rm -rf ${D}${sysconfdir}
 }
 
 # Ignore how TARGET_ARCH is computed.


### PR DESCRIPTION
Findlib configuration should be part of the sysroot. This prevents operations in the version control system to wipe it without Bitbake knowledge resulting in build failures (e.g, externalsrc).

Some entries require absolute path, so some substitution is required. Since the recipe paths are required are relative to the recipe, `do_populate_sysroot[postfuncs]` is not possible, instead add a
`prepare_recipe_sysroot[postfuncs]` in the class to handle the the changes.