### PR TITLE
S9: ocaml: use sysroot for dynamic libraries

### DIFF
--- a/classes/findlib.bbclass
+++ b/classes/findlib.bbclass
@@ -42,6 +42,7 @@ do_local_findlib_conf() {
     cat << EOF > ${OCAMLFIND_CONF}
 destdir="${D}${sitelibdir}"
 path="${OCAMLLIB}/site-lib:${STAGING_LIBDIR}/ocaml/site-lib"
+ldconf="ignore"
 EOF
 }
 addtask do_local_findlib_conf before do_configure after do_patch

--- a/recipes-devtools/camomile/camomile_0.8.5.bb
+++ b/recipes-devtools/camomile/camomile_0.8.5.bb
@@ -15,6 +15,7 @@ DEPENDS = " \
 SRC_URI = " \
     http://github.com/yoriyuki/Camomile/releases/download/rel-${PV}/camomile-${PV}.tar.bz2 \
     file://ocaml-camomile-destdir.patch \
+    file://ocaml-camomile-cc.patch \
 "
 SRC_URI[md5sum] = "1e25b6cd4efd26ab38a667db18d83f02"
 SRC_URI[sha256sum] = "85806b051cf059b93676a10a3f66051f7f322cad6e3248172c3e5275f79d7100"

--- a/recipes-devtools/camomile/files/ocaml-camomile-cc.patch
+++ b/recipes-devtools/camomile/files/ocaml-camomile-cc.patch
@@ -1,0 +1,15 @@
+Index: camomile-0.8.5/Makefile.in
+===================================================================
+--- camomile-0.8.5.orig/Makefile.in
++++ camomile-0.8.5/Makefile.in
+@@ -33,8 +33,8 @@ DATADIR=@datadir@
+ # other variables set by ./configure
+ CPPO = @CPPO@
+ FGREP = @FGREP@
+-OCAMLC   = @OCAMLC@
+-OCAMLOPT = @OCAMLOPT@
++OCAMLC   = @OCAMLC@ -cc '$(CC) $(CFLAGS)'
++OCAMLOPT = @OCAMLOPT@ -cc '$(CC) $(CFLAGS)'
+ OCAMLYACC = @OCAMLYACC@
+ OCAMLLEX = @OCAMLLEX@
+ OCAMLDEP = @OCAMLDEP@ -slash

--- a/recipes-devtools/ocaml-dbus/ocaml-dbus_0.24.bb
+++ b/recipes-devtools/ocaml-dbus/ocaml-dbus_0.24.bb
@@ -28,11 +28,9 @@ S = "${WORKDIR}/ocaml_dbus-${PV}"
 inherit ocaml findlib pkgconfig
 
 do_compile() {
-# TODO: There has to be a better way than this...
-# ocamlmklib should be able to figure out where the sysroot staging, apparently
-# OCAMLLIB does not cut it, neither does OCAML_TOPLEVEL_PATH, and get the
-# LDFLAGS.
-    oe_runmake OCAMLMKLIB="ocamlmklib -ldopt '--sysroot=${STAGING_DIR_TARGET} ${LDFLAGS}'"
+    oe_runmake \
+        OCAMLC="ocamlc -cc '${CC} -fPIC --sysroot=${STAGING_DIR_TARGET}'" \
+        OCAMLMKLIB="ocamlmklib -ldopt '--sysroot=${STAGING_DIR_TARGET} ${LDFLAGS}'"
 }
 
 do_install() {


### PR DESCRIPTION
Builds are now failing on recently created containers using the recommended Debian 8.11 environment for OCaml recipes producing dynamic libraries.

All errors relate to the toolchain not finding the required c runtime environment at different stages:

- ocaml-dbus ocamlc will use gcc without the sysroot compilation option:
```
| dbus_stubs.c:17:20: fatal error: string.h: No such file or directory
|  #include <string.h>
|                     ^
| compilation terminated.
```
- camomile does not pass the c-compiler flags down the chain, leading it to not find the cross-environment:
```
| ocamlopt.opt -noassert -I internal -I public -I toolslib -I . -o tools/parse_unidata.opt bigarray.cmxa str.cmxa toolslib.cmxa tools/parse_unidata.cmx
| [...]/camomile/0.8.5-r0/recipe-sysroot-native/usr/bin/x86_64-oe-linux/../../libexec/x86_64-oe-linux/gcc/x86_64-oe-linux/6.4.0/ld: cannot find crt1.o: No such file or directory
```
- findlib will default to use the ld.conf file of the native environment.