### PR TITLE
S9: OXT-1787: ocaml/findlib: fix toolchain cross environment

### DIFF
--- a/classes/findlib.bbclass
+++ b/classes/findlib.bbclass
@@ -42,6 +42,7 @@ do_local_findlib_conf() {
     cat << EOF > ${OCAMLFIND_CONF}
 destdir="${D}${sitelibdir}"
 path="${OCAMLLIB}/site-lib:${STAGING_LIBDIR}/ocaml/site-lib"
+ldconf="ignore"
 EOF
 }
 addtask do_local_findlib_conf before do_configure after do_patch

--- a/classes/ocaml.bbclass
+++ b/classes/ocaml.bbclass
@@ -14,6 +14,22 @@ OCAML_TOPLEVEL_PATH_class-cross = "${STAGING_LIBDIR_NATIVE}"
 OCAML_TOPLEVEL_PATH = "${STAGING_LIBDIR_NATIVE}/${TARGET_SYS}"
 export OCAML_TOPLEVEL_PATH
 
+# OCAML toolchain
+# Common variables used in Makfiles for OCAML projects.
+OCAMLMKLIB="ocamlmklib -ldopt '--sysroot=${STAGING_DIR_NATIVE}'"
+OCAMLC_class-target="ocamlc -cc '${CC} -fPIC'"
+OCAMLOPT_class-target="ocamlopt -cc '${CC} -fPIC'"
+OCAMLMKLIB_class-target="ocamlmklib -ldopt '--sysroot=${STAGING_DIR_TARGET} ${LDFLAGS}'"
+
+# Override Makefile variables with oe_runmake.
+EXTRA_OEMAKE_append += " \
+    OCAMLMKLIB="${OCAMLMKLIB}" \
+"
+EXTRA_OEMAKE_append_class-target += " \
+    OCAMLC="${OCAMLC}" \
+    OCAMLOPT="${OCAMLOPT}" \
+"
+
 DEPENDS_append_class-native = " \
     ocaml-native \
 "


### PR DESCRIPTION
Ocaml projects mostly use a common set of variables to find the native
and byte-code compiler. These in turn may use the appropriate C compiler
and libraries to interface with C sources and produce useable binaries.

Use the common OCAMLC, OCAMLOPT and OCAMLMKLIB to pass the appropriate
options from the ocaml bbclass. Also ignore the default ldconf in the
findlib bbclass as this will be provided through OE.