### PR TITLE
OXT-1787: ocaml/findlib: fix toolchain cross environment

### DIFF
--- a/classes/ocaml.bbclass
+++ b/classes/ocaml.bbclass
@@ -22,13 +22,13 @@ OCAMLOPT_class-target="ocamlopt -cc '${CC} -fPIC'"
 OCAMLMKLIB_class-target="ocamlmklib -ldopt '--sysroot=${STAGING_DIR_TARGET} ${LDFLAGS}'"
 
 # Override Makefile variables with oe_runmake.
-EXTRA_OEMAKE_append += " \
+EXTRA_OEMAKE_append += ' \
     OCAMLMKLIB="${OCAMLMKLIB}" \
-"
-EXTRA_OEMAKE_append_class-target += " \
+'
+EXTRA_OEMAKE_append_class-target += ' \
     OCAMLC="${OCAMLC}" \
     OCAMLOPT="${OCAMLOPT}" \
-"
+'
 
 DEPENDS_append_class-native = " \
     ocaml-native \

--- a/classes/ocaml.bbclass
+++ b/classes/ocaml.bbclass
@@ -14,6 +14,22 @@ OCAML_TOPLEVEL_PATH_class-cross = "${STAGING_LIBDIR_NATIVE}"
 OCAML_TOPLEVEL_PATH = "${STAGING_LIBDIR_NATIVE}/${TARGET_SYS}"
 export OCAML_TOPLEVEL_PATH
 
+# OCAML toolchain
+# Common variables used in Makfiles for OCAML projects.
+OCAMLMKLIB="ocamlmklib -ldopt '--sysroot=${STAGING_DIR_NATIVE}'"
+OCAMLC_class-target="ocamlc -cc '${CC} -fPIC'"
+OCAMLOPT_class-target="ocamlopt -cc '${CC} -fPIC'"
+OCAMLMKLIB_class-target="ocamlmklib -ldopt '--sysroot=${STAGING_DIR_TARGET} ${LDFLAGS}'"
+
+# Override Makefile variables with oe_runmake.
+EXTRA_OEMAKE_append += " \
+    OCAMLMKLIB="${OCAMLMKLIB}" \
+"
+EXTRA_OEMAKE_append_class-target += " \
+    OCAMLC="${OCAMLC}" \
+    OCAMLOPT="${OCAMLOPT}" \
+"
+
 DEPENDS_append_class-native = " \
     ocaml-native \
 "

--- a/recipes-devtools/ocaml/ocaml-cross_4.04.2.bb
+++ b/recipes-devtools/ocaml/ocaml-cross_4.04.2.bb
@@ -32,7 +32,6 @@ COMPATIBLE_MACHINE_x86-64 = "(.*)"
 do_configure_x86() {
     ./configure -no-curses \
                 -no-graph \
-                -no-shared-libs \
                 -no-debugger \
                 -no-ocamldoc \
                 -prefix ${prefix} \
@@ -52,7 +51,6 @@ do_configure_x86() {
 do_configure_x86-64() {
     ./configure -no-curses \
                 -no-graph \
-                -no-shared-libs \
                 -no-debugger \
                 -no-ocamldoc \
                 -prefix ${prefix} \

--- a/recipes-devtools/ocaml/ocaml-cross_4.04.2.bb
+++ b/recipes-devtools/ocaml/ocaml-cross_4.04.2.bb
@@ -42,7 +42,6 @@ do_configure_x86() {
                 -cc "${TARGET_PREFIX}gcc -fPIC -m32 --sysroot=${STAGING_DIR_TARGET}" \
                 -as "${TARGET_PREFIX}as --32" \
                 -aspp "${TARGET_PREFIX}gcc -fPIC -m32 -c" \
-                -libs "-Wl,--sysroot=${STAGING_DIR_TARGET}" \
                 -host ${TARGET_SYS} \
                 -partialld "ld -r -melf_i386" \
                 ${EXTRA_CONF}
@@ -61,7 +60,6 @@ do_configure_x86-64() {
                 -cc "${TARGET_PREFIX}gcc -fPIC --sysroot=${STAGING_DIR_TARGET}" \
                 -as "${TARGET_PREFIX}as" \
                 -aspp "${TARGET_PREFIX}gcc -c -fPIC" \
-                -libs "-Wl,--sysroot=${STAGING_DIR_TARGET}" \
                 -host ${TARGET_SYS} \
                 -partialld "${TARGET_PREFIX}ld -r" \
                 ${EXTRA_CONF}


### PR DESCRIPTION
- `ocaml.bbclass` now sets common ocaml toolchain variables (`OCAMLC`, `OCAMLOPT`, `OCAMLMKLIB`) with the required options to use the relevant sysroot;
- Fix some poor quoting in the above variables
- Re-enable dynamic libraries built from OCaml sources.
- Remove configure option in `ocaml-cross` that would break recipe-sysroot isolation.