### PR TITLE
S9: OXT-1787: ocaml: fix poor quoting

### DIFF
--- a/classes/ocaml.bbclass
+++ b/classes/ocaml.bbclass
@@ -22,13 +22,13 @@ OCAMLOPT_class-target="ocamlopt -cc '${CC} -fPIC'"
 OCAMLMKLIB_class-target="ocamlmklib -ldopt '--sysroot=${STAGING_DIR_TARGET} ${LDFLAGS}'"
 
 # Override Makefile variables with oe_runmake.
-EXTRA_OEMAKE_append += " \
+EXTRA_OEMAKE_append += ' \
     OCAMLMKLIB="${OCAMLMKLIB}" \
-"
-EXTRA_OEMAKE_append_class-target += " \
+'
+EXTRA_OEMAKE_append_class-target += ' \
     OCAMLC="${OCAMLC}" \
     OCAMLOPT="${OCAMLOPT}" \
-"
+'
 
 DEPENDS_append_class-native = " \
     ocaml-native \


### PR DESCRIPTION
bitbake processes single and double quote in the same way, it is recommended to use single quotes for values assigned to variables that contain double-quotes. In this case, it actually quotes the content as intended.