### PR TITLE
layer: switch compatibility to dunfell.

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -14,4 +14,4 @@ BBFILE_PATTERN_meta-openxt-ocaml-platform := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-openxt-ocaml-platform = "8"
 
 LAYERVERSION_meta-openxt-ocaml-platform = "2"
-LAYERSERIES_COMPAT_meta-openxt-ocaml-platform = "zeus"
+LAYERSERIES_COMPAT_meta-openxt-ocaml-platform = "dunfell"


### PR DESCRIPTION
Switch layer compatibility to dunfell.
Since this layer maintains a `zeus` branch, remove `zeus` from the compatibility list to not intend backward compatibility.

Required by: github.com/OpenXT/xenclient-oe/pull/1355