### PR TITLE
[ocaml] Add -fcommon to suppress GCC errors

### DIFF
--- a/recipes-devtools/ocaml/ocaml-4.04.inc
+++ b/recipes-devtools/ocaml/ocaml-4.04.inc
@@ -23,8 +23,8 @@ do_configure() {
 }
 do_configure_append() {
     # Make sure to turn off GCC stack-protector.
-    sed -i'' -re 's/NATIVECCCOMPOPTS=(.*)/NATIVECCCOMPOPTS=\1 -fno-stack-protector/' config/Makefile
-    sed -i'' -re 's/BYTECCCOMPOPTS=(.*)/BYTECCCOMPOPTS=\1 -fno-stack-protector/' config/Makefile
+    sed -i'' -re 's/NATIVECCCOMPOPTS=(.*)/NATIVECCCOMPOPTS=\1 -fno-stack-protector -fcommon/' config/Makefile
+    sed -i'' -re 's/BYTECCCOMPOPTS=(.*)/BYTECCCOMPOPTS=\1 -fno-stack-protector -fcommon/' config/Makefile
 }
 
 do_compile() {


### PR DESCRIPTION
GCC10+ has -fno-common set by default. This results in a slew of "multiple definition of..." errors during buildtime. Add -fcommon to fix this.

Note that we upgraded to a build container with gcc10 to fix a bug in the new GHC8 build.

This is part of the GHC8 uprev.  The parent PR against xenclient-oe can be found here:

https://github.com/OpenXT/xenclient-oe/pull/1469